### PR TITLE
add job name to help make artifact unique

### DIFF
--- a/src/srcclr.ts
+++ b/src/srcclr.ts
@@ -119,7 +119,7 @@ export async function runAction (options: Options)  {
             core.info('Store json Results as Artifact')
             const { DefaultArtifactClient } = require('@actions/artifact');
             const artifactClient = new DefaultArtifactClient();
-            const artifactName = 'Veracode Agent Based SCA Results';
+            const artifactName = 'Veracode Agent Based SCA Results ' + github.job; //append job here so it is unique
             const files = [
                 'scaResults.json'
             ]


### PR DESCRIPTION
Trying to follow what I _think_ would work to append the job name to the artifact name so it is unique. Not sure how best to test this, but here you go in case it is helpful. Job ID might be better, but getting that is trickier.

https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context