### PR TITLE
SDEVX-8414: Enable Platform-Specific Support for actions/artifact Versions (V3 for GHES, V4 for Cloud)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -53,6 +53,10 @@ inputs:
     description: "Run the SRCCLR with the `--no-graphs` option"
     required: false
     default: "false"
+  platformType:
+    description: 'Specifies the platform environment type — use CLOUD for GitHub.com or ENTERPRISE for GitHub Enterprise Server (GHES).'
+    default: 'CLOUD'
+    required: false
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@actions/artifact": "^2.1.4",
+        "@actions/artifact-v1": "npm:@actions/artifact@^1.1.1",
         "@actions/core": "^1.10.0",
         "@actions/github": "^5.0.0"
       },
@@ -39,6 +40,19 @@
         "jwt-decode": "^3.1.2",
         "twirp-ts": "^2.5.0",
         "unzip-stream": "^0.3.1"
+      }
+    },
+    "node_modules/@actions/artifact-v1": {
+      "name": "@actions/artifact",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@actions/artifact/-/artifact-1.1.2.tgz",
+      "integrity": "sha512-1gLONA4xw3/Q/9vGxKwkFdV9u1LE2RWGx/IpAqg28ZjprCnJFjwn4pA7LtShqg5mg5WhMek2fjpyH1leCmOlQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@actions/core": "^1.9.1",
+        "@actions/http-client": "^2.0.1",
+        "tmp": "^0.2.1",
+        "tmp-promise": "^3.0.2"
       }
     },
     "node_modules/@actions/core": {
@@ -1608,6 +1622,24 @@
       "integrity": "sha512-TmLJNj6UgX8xcUZo4UDStGQtDiTzF7BzWlzn9g7UWrjkpHr5uJTK1ld16wZ3LXb2vb6jH8qU89dW5whuMdXYdw==",
       "dependencies": {
         "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/tmp-promise": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+      "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tmp": "^0.2.0"
       }
     },
     "node_modules/tr46": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
+    "@actions/artifact-v1": "npm:@actions/artifact@^1.1.1",
     "@actions/artifact": "^2.1.4",
     "@actions/core": "^1.10.0",
     "@actions/github": "^5.0.0"

--- a/src/action.ts
+++ b/src/action.ts
@@ -18,8 +18,8 @@ const options: Options = {
     "skip-vms": core.getBooleanInput('skip-vms'),
     "no-graphs": core.getBooleanInput('no-graphs'),
     recursive: core.getBooleanInput('recursive'),
-    "skip-collectors": core.getInput('skip-collectors').split(',')
-    
+    "skip-collectors": core.getInput('skip-collectors').split(','),
+    platformType: core.getInput('platformType'),
 }
 
 runAction(options);

--- a/src/options.d.ts
+++ b/src/options.d.ts
@@ -13,6 +13,7 @@ export interface Options {
     "skip-vms":boolean,
     "no-graphs":boolean,
     "skip-collectors": Array<string>
+    platformType: string
 }
 
 

--- a/src/srcclr.ts
+++ b/src/srcclr.ts
@@ -118,7 +118,16 @@ export async function runAction (options: Options)  {
             //store output files as artifacts
             core.info('Store json Results as Artifact')
             const { DefaultArtifactClient } = require('@actions/artifact');
-            const artifactClient = new DefaultArtifactClient();
+            const artifactV1 = require('@actions/artifact-v1');
+            let artifactClient;
+
+            if (options?.platformType === 'ENTERPRISE') {
+                artifactClient = artifactV1.create();
+                core.info(`Initialized the artifact object using version V1.`);
+            } else {
+                artifactClient = new DefaultArtifactClient();
+                core.info(`Initialized the artifact object using version V2.`);
+            }
             const artifactName = 'Veracode Agent Based SCA Results';
             const files = [
                 'scaResults.json'
@@ -188,7 +197,16 @@ export async function runAction (options: Options)  {
                 //store output files as artifacts
                 core.info('Store txt Results as Artifact')
                 const { DefaultArtifactClient } = require('@actions/artifact');
-                const artifactClient = new DefaultArtifactClient();
+                const artifactV1 = require('@actions/artifact-v1');
+                let artifactClient;
+
+                if (options?.platformType === 'ENTERPRISE') {
+                    artifactClient = artifactV1.create();
+                    core.info(`Initialized the artifact object using version V1.`);
+                } else {
+                    artifactClient = new DefaultArtifactClient();
+                    core.info(`Initialized the artifact object using version V2.`);
+                }
                 const artifactName = 'Veracode Agent Based SCA Results';
                 const files = [
                     'scaResults.txt'

--- a/src/test/testRun.ts
+++ b/src/test/testRun.ts
@@ -17,7 +17,8 @@ const options: Options = {
     allowDirty: false,
     recursive:false,
     "skip-vms":false,
-    "no-graphs":false
+    "no-graphs":false,
+    platformType:'CLOUD'
 }
 
 runAction(options);


### PR DESCRIPTION
Since GHES supports only version V3 of actions/artifact, we’ve added support for both V3 and V4. Based on the platformType parameter, the appropriate actions/artifact object is created, with V4 set as the default for the Cloud environment.