### PR TITLE
scafix: support transitive dependency display for PRs

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -107405,7 +107405,7 @@ function generateVulnList(options) {
                 }
                 core.info(`Veracode CLI successfully installed and verified at: ${cliExecutablePath}`);
                 // Build the veracode fix sca command for Windows using full path
-                veracodeCommand = `"${cliExecutablePath}" fix sca "${workingDir}" -r "${workingDir}\\${index_1.SCA_OUTPUT_FILE}" --list-only --json "${vulnListingFile}"`;
+                veracodeCommand = `"${cliExecutablePath}" fix sca "${workingDir}" -r "${workingDir}\\${index_1.SCA_OUTPUT_FILE}" --list-only --transitive --json "${vulnListingFile}"`;
                 core.info(`Running command: ${veracodeCommand}`);
             }
             else {
@@ -107425,7 +107425,7 @@ function generateVulnList(options) {
                 cliExecutablePath = `${helperCliPath}/${cliFileName}`;
                 core.info(`CLI executable path: ${cliExecutablePath}`);
                 // Build the veracode fix sca command
-                veracodeCommand = `${cliExecutablePath}/veracode fix sca "${workingDir}" -r "${workingDir}/${index_1.SCA_OUTPUT_FILE}" --list-only --json "${vulnListingFile}"`;
+                veracodeCommand = `${cliExecutablePath}/veracode fix sca "${workingDir}" -r "${workingDir}/${index_1.SCA_OUTPUT_FILE}" --list-only --transitive --json "${vulnListingFile}"`;
                 core.info(`Running command: ${veracodeCommand}`);
             }
             // Run the veracode fix sca command

--- a/src/srcclr.ts
+++ b/src/srcclr.ts
@@ -928,7 +928,7 @@ async function generateVulnList(options: Options): Promise<void> {
             core.info(`Veracode CLI successfully installed and verified at: ${cliExecutablePath}`);
 
             // Build the veracode fix sca command for Windows using full path
-            veracodeCommand = `"${cliExecutablePath}" fix sca "${workingDir}" -r "${workingDir}\\${SCA_OUTPUT_FILE}" --list-only --json "${vulnListingFile}"`;
+            veracodeCommand = `"${cliExecutablePath}" fix sca "${workingDir}" -r "${workingDir}\\${SCA_OUTPUT_FILE}" --list-only --transitive --json "${vulnListingFile}"`;
 
             core.info(`Running command: ${veracodeCommand}`);
 
@@ -954,7 +954,7 @@ async function generateVulnList(options: Options): Promise<void> {
             core.info(`CLI executable path: ${cliExecutablePath}`);
 
             // Build the veracode fix sca command
-            veracodeCommand = `${cliExecutablePath}/veracode fix sca "${workingDir}" -r "${workingDir}/${SCA_OUTPUT_FILE}" --list-only --json "${vulnListingFile}"`;
+            veracodeCommand = `${cliExecutablePath}/veracode fix sca "${workingDir}" -r "${workingDir}/${SCA_OUTPUT_FILE}" --list-only --transitive --json "${vulnListingFile}"`;
 
             core.info(`Running command: ${veracodeCommand}`);
         }


### PR DESCRIPTION
## What Changed
- add transitive dependency support for --list-only scafix command

## Why it Changed
- previously, the incorrect number of vulnerabilities were displayed on an sca-fix eligible PR if there were vulnerabilities present in transitive libraries.

## Local Testing Below...
<img width="717" height="810" alt="image" src="https://github.com/user-attachments/assets/e859d607-d656-48a1-a481-dcd17bd936dc" />
